### PR TITLE
section added in metada package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ par-map = "0.1"
 
 [dev-dependencies]
 testcontainers = "0.7"
+
+[package.metadata.deb]
+section = "base"


### PR DESCRIPTION
Before correction:
command : `dpkg-deb -I cosmogony2cities_0.1.0_amd64.deb`
output: 

****************************************************
 new Debian package, version 2.0.
 size 902100 bytes: control archive=371 bytes.
     271 bytes,    10 lines      control              
     134 bytes,     2 lines      md5sums              
 Package: cosmogony2cities
 Version: 0.1.0
 Architecture: amd64
 Priority: optional
 Standards-Version: 3.9.4
 Maintainer: antoine-de <antoine.desbordes@gmail.com>
 Installed-Size: 3398
 Depends: libc6 (>= 2.19)
 Description: Import cosmogony's cities into a postgresql database
****************************************************
After correction:

command : `dpkg-deb -I cosmogony2cities_0.1.0_amd64.deb`
output: 

****************************************************
 new Debian package, version 2.0.
 size 877286 bytes: control archive=377 bytes.
     285 octets,    11 lignes      control              
     134 octets,     2 lignes      md5sums              
 Package: cosmogony2cities
 Version: 0.1.0
 Architecture: amd64
 **Section: base**
 Priority: optional
 Standards-Version: 3.9.4
 Maintainer: antoine-de <antoine.desbordes@gmail.com>
 Installed-Size: 3314
 Depends: libc6 (>= 2.31)
 Description: Import cosmogony's cities into a postgresql database

****************************************************